### PR TITLE
Upgrade sdc-qrf

### DIFF
--- a/contrib/aidbox/index.ts
+++ b/contrib/aidbox/index.ts
@@ -14301,7 +14301,7 @@ export interface Questionnaire {
     lastReviewDate?: date;
     /** NOTE: from extension http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-launchContext */
     launchContext?: QuestionnaireLaunchContext[];
-    /** NOTE: from extension http://beda.software/fhir-extensions/questionnaire-mapper */
+    /** NOTE: from extension https://emr.beda.software/StructureDefinition/questionnaire-mapper */
     /** List of mapping resources that must be executed on extract */
     mapping?: Array<InternalReference<Mapping>>;
     /** Extensions that cannot be ignored */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@beda.software/fhir-questionnaire",
-  "version": "1.0.0",
+  "version": "2.0.0-alpha.0",
   "main": "index.ts",
   "peerDependencies": {
     "@types/react": "*",
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "jest"
-},
+  },
   "dependencies": {
     "@beda.software/fhir-react": "^1.8.6",
     "@beda.software/remote-data": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "query-string": "^7.1.1",
     "react-hook-form": "^7.49.3",
     "@hookform/resolvers": "^3.1.1",
-    "sdc-qrf": "^0.3.15",
+    "sdc-qrf": "^1.0.0-alpha.0",
     "yup": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Upgrade sdc-qrf wich has backward incompatible changes in part of Beda Software FHIR extensions and profile URL

See [release notes](https://github.com/beda-software/sdc-qrf/releases/tag/v1.0.0-alpha.0) for details