### PR TITLE
WIP Resolve to source for React Native / Metro consumers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,28 +3,42 @@
     "version": "0.1.0-alpha.10",
     "type": "module",
     "main": "./dist/index.js",
+    "react-native": "./index.ts",
+    "source": "./index.ts",
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {
-            "types": "./dist/index.d.ts",
+            "types": "./index.ts",
+            "react-native": "./index.ts",
+            "browser": "./index.ts",
             "import": "./dist/index.js"
         },
         "./components": {
-            "types": "./dist/components/index.d.ts",
+            "types": "./components/index.ts",
+            "react-native": "./components/index.ts",
+            "browser": "./components/index.ts",
             "import": "./dist/components/index.js"
         },
         "./contexts": {
-            "types": "./dist/contexts/index.d.ts",
+            "types": "./contexts/index.ts",
+            "react-native": "./contexts/index.ts",
+            "browser": "./contexts/index.ts",
             "import": "./dist/contexts/index.js"
         },
         "./services": {
-            "types": "./dist/services/index.d.ts",
+            "types": "./services/index.ts",
+            "react-native": "./services/index.ts",
+            "browser": "./services/index.ts",
             "import": "./dist/services/index.js"
         },
         "./package.json": "./package.json"
     },
     "files": [
         "dist",
+        "index.ts",
+        "components",
+        "contexts",
+        "services",
         "README.md",
         "components/locale"
     ],

--- a/package.json
+++ b/package.json
@@ -2,51 +2,31 @@
     "name": "@beda.software/fhir-questionnaire",
     "version": "0.1.0-alpha.10",
     "type": "module",
-    "main": "./dist/index.js",
+    "main": "./index.ts",
     "react-native": "./index.ts",
     "source": "./index.ts",
-    "types": "./dist/index.d.ts",
+    "types": "./index.ts",
     "exports": {
         ".": {
-            "react-native": {
-                "types": "./index.ts",
-                "default": "./index.ts"
-            },
-            "types": "./dist/index.d.ts",
-            "import": "./dist/index.js"
+            "types": "./index.ts",
+            "default": "./index.ts"
         },
         "./components": {
-            "react-native": {
-                "types": "./components/index.ts",
-                "default": "./components/index.ts"
-            },
-            "types": "./dist/components/index.d.ts",
-            "import": "./dist/components/index.js"
+            "types": "./components/index.ts",
+            "default": "./components/index.ts"
         },
         "./contexts": {
-            "react-native": {
-                "types": "./contexts/index.ts",
-                "default": "./contexts/index.ts"
-            },
-            "types": "./dist/contexts/index.d.ts",
-            "import": "./dist/contexts/index.js"
+            "types": "./contexts/index.ts",
+            "default": "./contexts/index.ts"
         },
         "./services": {
-            "react-native": {
-                "types": "./services/index.ts",
-                "default": "./services/index.ts"
-            },
-            "types": "./dist/services/index.d.ts",
-            "import": "./dist/services/index.js"
+            "types": "./services/index.ts",
+            "default": "./services/index.ts"
         },
         "./package.json": "./package.json"
     },
     "files": [
         "dist",
-        "index.ts",
-        "components",
-        "contexts",
-        "services",
         "README.md",
         "components/locale"
     ],
@@ -64,7 +44,28 @@
         "typescript": "*"
     },
     "publishConfig": {
-        "access": "public"
+        "access": "public",
+        "main": "./dist/index.js",
+        "types": "./dist/index.d.ts",
+        "exports": {
+            ".": {
+                "types": "./dist/index.d.ts",
+                "import": "./dist/index.js"
+            },
+            "./components": {
+                "types": "./dist/components/index.d.ts",
+                "import": "./dist/components/index.js"
+            },
+            "./contexts": {
+                "types": "./dist/contexts/index.d.ts",
+                "import": "./dist/contexts/index.js"
+            },
+            "./services": {
+                "types": "./dist/services/index.d.ts",
+                "import": "./dist/services/index.js"
+            },
+            "./package.json": "./package.json"
+        }
     },
     "scripts": {
         "test": "vitest",

--- a/package.json
+++ b/package.json
@@ -8,27 +8,35 @@
     "types": "./dist/index.d.ts",
     "exports": {
         ".": {
-            "types": "./index.ts",
-            "react-native": "./index.ts",
-            "browser": "./index.ts",
+            "react-native": {
+                "types": "./index.ts",
+                "default": "./index.ts"
+            },
+            "types": "./dist/index.d.ts",
             "import": "./dist/index.js"
         },
         "./components": {
-            "types": "./components/index.ts",
-            "react-native": "./components/index.ts",
-            "browser": "./components/index.ts",
+            "react-native": {
+                "types": "./components/index.ts",
+                "default": "./components/index.ts"
+            },
+            "types": "./dist/components/index.d.ts",
             "import": "./dist/components/index.js"
         },
         "./contexts": {
-            "types": "./contexts/index.ts",
-            "react-native": "./contexts/index.ts",
-            "browser": "./contexts/index.ts",
+            "react-native": {
+                "types": "./contexts/index.ts",
+                "default": "./contexts/index.ts"
+            },
+            "types": "./dist/contexts/index.d.ts",
             "import": "./dist/contexts/index.js"
         },
         "./services": {
-            "types": "./services/index.ts",
-            "react-native": "./services/index.ts",
-            "browser": "./services/index.ts",
+            "react-native": {
+                "types": "./services/index.ts",
+                "default": "./services/index.ts"
+            },
+            "types": "./dist/services/index.d.ts",
             "import": "./dist/services/index.js"
         },
         "./package.json": "./package.json"


### PR DESCRIPTION
## Problem

This package is published as a built package — `main`, `types`, and every
`exports` subpath point at `./dist/**`. That's correct for npm/Node, but
React Native monorepos commonly vendor it as a **source submodule** with no
build step and resolve it through Metro.

In that setup nothing under `dist/` exists, so:

- **Metro** resolves the package via `resolverMainFields`
  (`['react-native', 'browser', 'main']`). With no `react-native`/`source`
  field it falls through to `main` → `./dist/index.js` and throws
  *"specifies a `main` module field that could not be resolved"*.
- **TypeScript** (`moduleResolution: bundler`) reads `exports[...].types` →
  `./dist/index.d.ts` and reports *"Cannot find module ..."*.

## Change

Expose the TypeScript source to React Native consumers while keeping the
published `dist` contract for npm/Node:

- Add top-level `"react-native": "./index.ts"` and `"source": "./index.ts"`,
  used by Metro's `resolverMainFields`.
- Add a `react-native` export condition (nested `types` + `default` → source)
  to each subpath, so RN bundlers and TypeScript with
  `customConditions: ["react-native"]` resolve the source.
- Keep `"types"` → `./dist/**.d.ts` and `"import"` → `./dist/**.js`, so
  npm/Node consumers keep using the built declarations and JS.
- Add the source entry points (`index.ts`, `components`, `contexts`,
  `services`) to `files` so the `react-native` condition is also valid when
  installed from npm.

Only `package.json` changes.

## Compatibility

- **npm / Node**: unchanged — `import` → `./dist/**.js`, `types` →
  `./dist/**.d.ts` (built declarations preserved).
- **React Native / Metro**: resolves to source via the top-level
  `react-native`/`source` field and the `react-native` export condition
  (Expo Metro injects `react-native` into the export conditions for
  iOS/Android).
- **TypeScript**: resolves to source under the `react-native` custom
  condition; default (npm) TypeScript still resolves the built `.d.ts`.

## Testing

Verified in a React Native (Expo SDK 54, Metro 0.83, React 19) workspace
consuming this package as a source submodule: Metro bundles and TypeScript
type-checks against the source, questionnaire forms render at runtime, and
npm-style resolution still points at `dist`.